### PR TITLE
fix: solve several issues about headers and lib distribution

### DIFF
--- a/examples/matrix.c
+++ b/examples/matrix.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "../src//utils/check_alloc.h"
+#include "../src/utils/check_alloc.h"
 
 
 // aloca uma matrix como um vetor contínuo

--- a/src/circle/circle.c
+++ b/src/circle/circle.c
@@ -12,7 +12,7 @@
 
 #include <stdlib.h>
 #include "circle.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 Circle* circle_create(Point *center, float radius) {
     Circle* c = (Circle *) malloc(sizeof(Circle));

--- a/src/console/console.h
+++ b/src/console/console.h
@@ -13,7 +13,7 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
-#include "console/pause.h"
-#include "console/clear.h"
+#include "pause.h"
+#include "clear.h"
 
 #endif

--- a/src/ds-lerax.h
+++ b/src/ds-lerax.h
@@ -27,5 +27,7 @@
 #include "tree/ascii-tree/ascii-tree.h"
 #include "tree/binary-tree.h"
 #include "tree/bst/bst.h"
+#include "tree/avl/avl.h"
+#include "search/search.h"
 
 #endif

--- a/src/list/circular/test.c
+++ b/src/list/circular/test.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "list-circular.h"
-#include "console/console.h"
+#include "../../console/console.h"
 
 int main(void) {
     ListCircular* l = list_circular_create();

--- a/src/list/double/list-double.c
+++ b/src/list/double/list-double.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "list-double.h"
-#include "utils/check_alloc.h"
+#include "../../utils/check_alloc.h"
 
 
 ListDouble* list_double__new_node(int data) {

--- a/src/list/double/test.c
+++ b/src/list/double/test.c
@@ -11,7 +11,7 @@
  */
 
 #include <stdio.h>
-#include "console/console.h"
+#include "../../console/console.h"
 #include "list-double.h"
 
 int main(void) {

--- a/src/list/single/list-common.c
+++ b/src/list/single/list-common.c
@@ -19,7 +19,7 @@
 #include <math.h>
 #include <stdarg.h>
 #include "list.h"
-#include "utils/check_alloc.h"
+#include "../../utils/check_alloc.h"
 
 List* list_create(void) {
     return NULL;

--- a/src/list/single/list-rec.c
+++ b/src/list/single/list-rec.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "list.h"
-#include "utils/check_alloc.h"
+#include "../../utils/check_alloc.h"
 
 
 // auxiliar print recursively list (without squared brackets)

--- a/src/list/single/test.c
+++ b/src/list/single/test.c
@@ -16,7 +16,7 @@
 
 
 #include "list.h"
-#include "console/console.h"
+#include "../../console/console.h"
 #include <stdio.h>
 
 void test_basic_functions(void) {

--- a/src/matrix/matrix-pointer.c
+++ b/src/matrix/matrix-pointer.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "matrix.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 struct matrix {
     int lines;

--- a/src/matrix/matrix-vector.c
+++ b/src/matrix/matrix-vector.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "matrix.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 struct matrix {
     int lines;

--- a/src/point/point.c
+++ b/src/point/point.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include "point.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 
 Point* point_create(float x, float y) {

--- a/src/queue/queue-dynamic.c
+++ b/src/queue/queue-dynamic.c
@@ -12,8 +12,8 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include "list/single/list.h"
-#include "utils/check_alloc.h"
+#include "../list/single/list.h"
+#include "../utils/check_alloc.h"
 #include "queue.h"
 
 struct queue {

--- a/src/queue/queue-static.c
+++ b/src/queue/queue-static.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "queue.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 struct queue {
     int size;

--- a/src/queue/test.c
+++ b/src/queue/test.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include "queue.h"
-#include "console/console.h"
+#include "../console/console.h"
 
 int main(void) {
     Queue* q = queue_create();

--- a/src/search/search.c
+++ b/src/search/search.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 
 #include "search.h"
+#include "../utils/prime.h"
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define ALPHABET 128
@@ -115,24 +116,6 @@ int search_bm(char *text, const char *pattern) {
 
 }
 
-bool _is_prime(int n) {
-    if (n < 2) {
-        return false;
-    }
-    for (int q = 2; q < sqrt(n) + 1; q++) {
-        if (n % q == 0) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-int next_prime(int q) {
-    int i = q + 1;
-    while (!_is_prime(i)) i++;
-    return i;
-}
 
 int check_substring(char *text, const char *pattern) {
     int m = strlen(pattern);

--- a/src/sort/radixsort.c
+++ b/src/sort/radixsort.c
@@ -15,7 +15,7 @@
 #include <math.h>
 #include <stdio.h>
 
-#include "queue/queue.h"
+#include "../queue/queue.h"
 #include "sort.h"
 
 

--- a/src/sort/utils.c
+++ b/src/sort/utils.c
@@ -16,7 +16,7 @@
 #include <stdarg.h>
 #include <time.h>
 #include "sort.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 void print_vector(Type *v, int n) {
     printf("[");

--- a/src/stack/stack-dynamic.c
+++ b/src/stack/stack-dynamic.c
@@ -13,8 +13,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "stack.h"
-#include "utils/check_alloc.h"
-#include "list/single/list.h"
+#include "../utils/check_alloc.h"
+#include "../list/single/list.h"
 
 struct stack {
     List* list;

--- a/src/stack/stack-static.c
+++ b/src/stack/stack-static.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "stack.h"
-#include "utils/check_alloc.h"
+#include "../utils/check_alloc.h"
 
 struct stack {
     int n;

--- a/src/stack/test.c
+++ b/src/stack/test.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include "stack.h"
-#include "console/console.h"
+#include "../console/console.h"
 
 int main(void) {
     Stack* p1 = stack_create();

--- a/src/tree/ascii-tree/ascii-tree.h
+++ b/src/tree/ascii-tree/ascii-tree.h
@@ -14,12 +14,10 @@
 #ifndef ASCII_H
 #define ASCII_H
 
-#ifndef DS_UFC_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#endif
-#include "tree/binary-tree.h"
+#include "../binary-tree.h"
 
 /**
  * @description

--- a/src/tree/ascii-tree/test.c
+++ b/src/tree/ascii-tree/test.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "tree/bst/bst.h"
+#include "../bst/bst.h"
 #include "ascii-tree.h"
 
 int main() {

--- a/src/tree/avl/avl.c
+++ b/src/tree/avl/avl.c
@@ -15,7 +15,8 @@
 #include <stdbool.h>
 #include <math.h>
 #include "avl.h"
-#include "utils/check_alloc.h"
+#include "../../utils/check_alloc.h"
+#include "../../utils/prime.h"
 
 
 // New auxiliary methods
@@ -281,30 +282,14 @@ void avl_infix(AVLTree *t) {
 
 // a)
 
-int is_leaf(AVLTree *t) {
+int avl_is_leaf(AVLTree *t) {
     return t != NULL && t->left == NULL && t->right == NULL;
 }
 
-// Worst: O(sqrt(n))
-int is_prime(int n) {
-    if (n == 2) {
-        return true;
-    } else if (n <= 1 || n % 2 == 0) {
-        return false;
-    }
-
-    for (int k = 3; k <= floor(sqrt(n)); k += 2) {
-        if (n % k == 0) {
-            return false;
-        }
-    }
-
-    return true;
-}
 
 int avl_leafs_primes(AVLTree *t) {
     if (!avl_empty(t)) {
-        if (is_leaf(t)) {
+        if (avl_is_leaf(t)) {
             return is_prime(t->value);
         } else {
             return avl_leafs_primes(t->left) + avl_leafs_primes(t->right);

--- a/src/tree/avl/avl.h
+++ b/src/tree/avl/avl.h
@@ -23,7 +23,8 @@
 
 
 /* Binary Search Tree DataType Definition */
-#include "tree/avl/binary-tree.h"
+#include "binary-tree.h"
+
 typedef struct BinaryNode AVLTree;
 #ifndef Type
 #define Type BINARY_NODE_TYPE

--- a/src/tree/avl/test.c
+++ b/src/tree/avl/test.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include "avl.h"
-#include "tree/ascii-tree/ascii-tree.h"
+#include "../ascii-tree/ascii-tree.h"
 
 #define N 5
 

--- a/src/tree/bst/bst.c
+++ b/src/tree/bst/bst.c
@@ -15,7 +15,8 @@
 #include <stdbool.h>
 #include <math.h>
 #include "bst.h"
-#include "utils/check_alloc.h"
+#include "../../utils/check_alloc.h"
+#include "../../utils/prime.h"
 
 #define MAX(a, b) a > b? a : b
 
@@ -190,30 +191,13 @@ void bst_infix(BSTree *t) {
 
 // a)
 
-int is_leaf(BSTree *t) {
+int bst_is_leaf(BSTree *t) {
     return t != NULL && t->left == NULL && t->right == NULL;
-}
-
-// Worst: O(sqrt(n))
-int is_prime(int n) {
-    if (n == 2) {
-        return true;
-    } else if (n <= 1 || n % 2 == 0) {
-        return false;
-    }
-
-    for (int k = 3; k <= floor(sqrt(n)); k += 2) {
-        if (n % k == 0) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 int bst_leafs_primes(BSTree *t) {
     if (!bst_empty(t)) {
-        if (is_leaf(t)) {
+        if (bst_is_leaf(t)) {
             return is_prime(t->value);
         } else {
             return bst_leafs_primes(t->left) + bst_leafs_primes(t->right);

--- a/src/tree/bst/bst.h
+++ b/src/tree/bst/bst.h
@@ -20,7 +20,7 @@
  */
 
 // definition of BinaryTree and struct node.
-#include "tree/binary-tree.h"
+#include "../binary-tree.h"
 
 /* Binary Search Tree DataType Definition */
 typedef struct BinaryNode BSTree;

--- a/src/tree/bst/test.c
+++ b/src/tree/bst/test.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include "bst.h"
-#include "tree/ascii-tree/ascii-tree.h"
+#include "../ascii-tree/ascii-tree.h"
 
 #define N 5
 

--- a/src/tree/main.c
+++ b/src/tree/main.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include "avl/avl.h"
 #include "ascii-tree/ascii-tree.h"
-#include "console/console.h"
+#include "../console/console.h"
 
 /**
  * @description

--- a/src/utils/check_alloc.h
+++ b/src/utils/check_alloc.h
@@ -12,10 +12,9 @@
 
 #ifndef CHECK_ALLOC_H
 #define CHECK_ALLOC_H
-#ifndef DS_UFC_H
+
 #include <stdio.h>
 #include <stdlib.h>
-#endif
 
 // wondering why the `static` here?
 // the inline is just to expand as macro instead to define a function

--- a/src/utils/prime.h
+++ b/src/utils/prime.h
@@ -1,0 +1,30 @@
+#ifndef PRIME_H
+#define PRIME_H
+
+#include <stdbool.h>
+#include <math.h>
+
+// Worst: O(sqrt(n))
+static inline int is_prime(int n) {
+    if (n == 2) {
+        return true;
+    } else if (n <= 1 || n % 2 == 0) {
+        return false;
+    }
+
+    for (int k = 3; k <= floor(sqrt(n)); k += 2) {
+        if (n % k == 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static inline int next_prime(int q) {
+    int i = q + 1;
+    while (!is_prime(i)) i++;
+    return i;
+}
+
+#endif


### PR DESCRIPTION
- use relative includes always to make portable
- instead concatenate all headers into a single header-only file, copy
  the lib structure to lib/ dir
- add make uninstall
- use default lib target /usr/lib instead /usr/local/lib (didn't work)
  for make install
- include avl and search to src/ds-lerax.h
- add utils/prime.h header to avoid duplicated definitions
- remove more DS_UFC macro references